### PR TITLE
[ISSUE #132]Define filtering rules to synchronize only filtered messages

### DIFF
--- a/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/RmqSourceReplicator.java
+++ b/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/RmqSourceReplicator.java
@@ -214,7 +214,8 @@ public class RmqSourceReplicator extends SourceConnector {
             DataType.COMMON_MESSAGE.ordinal(),
             this.replicatorConfig.isSrcAclEnable(),
             this.replicatorConfig.getSrcAccessKey(),
-            this.replicatorConfig.getSrcSecretKey()
+            this.replicatorConfig.getSrcSecretKey(),
+            this.replicatorConfig.getFilterRule()
         );
         return this.replicatorConfig.getTaskDivideStrategy().divide(this.topicRouteMap, tdc, maxTasks);
     }

--- a/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/RmqSourceTask.java
+++ b/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/RmqSourceTask.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.acl.common.AclClientRPCHook;
 import org.apache.rocketmq.acl.common.SessionCredentials;
 import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
@@ -55,6 +56,8 @@ import org.slf4j.LoggerFactory;
 public class RmqSourceTask extends SourceTask {
 
     private static final Logger log = LoggerFactory.getLogger(RmqSourceTask.class);
+
+    private static final String NULL_STR = "null";
 
     private final String taskId;
     private final TaskConfig config;
@@ -162,7 +165,9 @@ public class RmqSourceTask extends SourceTask {
         if (started) {
             try {
                 for (TaskTopicInfo taskTopicConfig : this.mqOffsetMap.keySet()) {
-                    PullResult pullResult = consumer.pull(taskTopicConfig, "*",
+                    String subExpression = (StringUtils.isEmpty(this.config.getFilterRule()) || NULL_STR.equals(this.config.getFilterRule()))
+                        ? "*" : this.config.getFilterRule();
+                    PullResult pullResult = consumer.pull(taskTopicConfig, subExpression,
                         this.mqOffsetMap.get(taskTopicConfig), 32);
                     switch (pullResult.getPullStatus()) {
                         case FOUND: {

--- a/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/config/ConfigDefine.java
+++ b/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/config/ConfigDefine.java
@@ -51,6 +51,8 @@ public class ConfigDefine {
 
     public static final String OFFSET_SYNC_TOPIC = "offset.sync.topic";
 
+    public static final String FILTER_RULE = "filter-rule";
+
     /**
      * The required key for all configurations.
      */

--- a/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/config/RmqConnectorConfig.java
+++ b/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/config/RmqConnectorConfig.java
@@ -42,6 +42,7 @@ public class RmqConnectorConfig {
     private boolean targetAclEnable = false;
     private String targetAccessKey;
     private String targetSecretKey;
+    private String filterRule;
 
     public RmqConnectorConfig() {
     }
@@ -67,6 +68,7 @@ public class RmqConnectorConfig {
         refreshInterval = config.getLong(ConfigDefine.REFRESH_INTERVAL, 3);
         renamePattern = config.getString(ConfigDefine.CONN_TOPIC_RENAME_FMT);
         offsetSyncTopic = config.getString(ConfigDefine.OFFSET_SYNC_TOPIC);
+        filterRule = config.getString(ConfigDefine.FILTER_RULE);
 
         if (config.containsKey(ConfigDefine.CONN_SOURCE_ACL_ENABLE)) {
             srcAclEnable = Boolean.parseBoolean(config.getString(ConfigDefine.CONN_SOURCE_ACL_ENABLE));
@@ -161,5 +163,9 @@ public class RmqConnectorConfig {
 
     public String getTargetSecretKey() {
         return targetSecretKey;
+    }
+
+    public String getFilterRule() {
+        return filterRule;
     }
 }

--- a/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/config/TaskConfig.java
+++ b/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/config/TaskConfig.java
@@ -30,6 +30,7 @@ public class TaskConfig {
     private boolean srcAclEnable = false;
     private String srcAccessKey;
     private String srcSecretKey;
+    private String filterRule;
 
     public String getSourceGroup() {
         return sourceGroup;
@@ -129,5 +130,13 @@ public class TaskConfig {
 
     public void setSrcSecretKey(String srcSecretKey) {
         this.srcSecretKey = srcSecretKey;
+    }
+
+    public String getFilterRule() {
+        return filterRule;
+    }
+
+    public void setFilterRule(String filterRule) {
+        this.filterRule = filterRule;
     }
 }

--- a/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/config/TaskConfigEnum.java
+++ b/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/config/TaskConfigEnum.java
@@ -34,7 +34,8 @@ public enum TaskConfigEnum {
     TASK_SOURCE_RECORD_CONVERTER("source-record-converter"),
     TASK_SOURCE_ACL_ENABLE("srcAclEnable"),
     TASK_SOURCE_ACCESS_KEY("srcAccessKey"),
-    TASK_SOURCE_SECRET_KEY("srcSecretKey");
+    TASK_SOURCE_SECRET_KEY("srcSecretKey"),
+    TASK_FILTER_RULE("filterRule");
 
     private String key;
 

--- a/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/config/TaskDivideConfig.java
+++ b/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/config/TaskDivideConfig.java
@@ -34,8 +34,10 @@ public class TaskDivideConfig {
 
     private String srcSecretKey;
 
+    private String filterRule;
+
     public TaskDivideConfig(String sourceNamesrvAddr, String srcCluster, String storeTopic, String srcRecordConverter,
-        int dataType, boolean srcAclEnable, String srcAccessKey, String srcSecretKey) {
+        int dataType, boolean srcAclEnable, String srcAccessKey, String srcSecretKey, String filterRule) {
         this.sourceNamesrvAddr = sourceNamesrvAddr;
         this.srcCluster = srcCluster;
         this.storeTopic = storeTopic;
@@ -44,6 +46,7 @@ public class TaskDivideConfig {
         this.srcAclEnable = srcAclEnable;
         this.srcAccessKey = srcAccessKey;
         this.srcSecretKey = srcSecretKey;
+        this.filterRule = filterRule;
     }
 
     public String getSourceNamesrvAddr() {
@@ -108,5 +111,13 @@ public class TaskDivideConfig {
 
     public void setSrcSecretKey(String srcSecretKey) {
         this.srcSecretKey = srcSecretKey;
+    }
+
+    public String getFilterRule() {
+        return filterRule;
+    }
+
+    public void setFilterRule(String filterRule) {
+        this.filterRule = filterRule;
     }
 }

--- a/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/strategy/DivideTaskByConsistentHash.java
+++ b/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/strategy/DivideTaskByConsistentHash.java
@@ -67,6 +67,7 @@ public class DivideTaskByConsistentHash extends TaskDivideStrategy {
             keyValue.put(TaskConfigEnum.TASK_SOURCE_ACL_ENABLE.getKey(), String.valueOf(tdc.isSrcAclEnable()));
             keyValue.put(TaskConfigEnum.TASK_SOURCE_ACCESS_KEY.getKey(), tdc.getSrcAccessKey());
             keyValue.put(TaskConfigEnum.TASK_SOURCE_SECRET_KEY.getKey(), tdc.getSrcSecretKey());
+            keyValue.put(TaskConfigEnum.TASK_FILTER_RULE.getKey(), tdc.getFilterRule());
             config.add(keyValue);
         }
 

--- a/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/strategy/DivideTaskByQueue.java
+++ b/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/strategy/DivideTaskByQueue.java
@@ -62,6 +62,7 @@ public class DivideTaskByQueue extends TaskDivideStrategy {
             keyValue.put(TaskConfigEnum.TASK_SOURCE_ACL_ENABLE.getKey(), String.valueOf(tdc.isSrcAclEnable()));
             keyValue.put(TaskConfigEnum.TASK_SOURCE_ACCESS_KEY.getKey(), tdc.getSrcAccessKey());
             keyValue.put(TaskConfigEnum.TASK_SOURCE_SECRET_KEY.getKey(), tdc.getSrcSecretKey());
+            keyValue.put(TaskConfigEnum.TASK_FILTER_RULE.getKey(), tdc.getFilterRule());
             config.add(keyValue);
         }
 

--- a/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/strategy/DivideTaskByTopic.java
+++ b/connectors/rocketmq-replicator/src/main/java/org/apache/rocketmq/replicator/strategy/DivideTaskByTopic.java
@@ -54,6 +54,7 @@ public class DivideTaskByTopic extends TaskDivideStrategy {
             keyValue.put(TaskConfigEnum.TASK_SOURCE_ACL_ENABLE.getKey(), String.valueOf(tdc.isSrcAclEnable()));
             keyValue.put(TaskConfigEnum.TASK_SOURCE_ACCESS_KEY.getKey(), tdc.getSrcAccessKey());
             keyValue.put(TaskConfigEnum.TASK_SOURCE_SECRET_KEY.getKey(), tdc.getSrcSecretKey());
+            keyValue.put(TaskConfigEnum.TASK_FILTER_RULE.getKey(), tdc.getFilterRule());
             config.add(keyValue);
         }
 

--- a/connectors/rocketmq-replicator/src/test/java/org/apache/rocketmq/replicator/DefaultTaskDivideStrategyTest.java
+++ b/connectors/rocketmq-replicator/src/test/java/org/apache/rocketmq/replicator/DefaultTaskDivideStrategyTest.java
@@ -78,7 +78,8 @@ public class DefaultTaskDivideStrategyTest {
             DataType.COMMON_MESSAGE.ordinal(),
             false,
             "",
-            ""
+            "",
+            "TagA"
         );
         List<KeyValue> taskConfigs = config.getTaskDivideStrategy().divide(topicRouteMap, tdc, 4);
         assertThat(taskConfigs.size()).isEqualTo(4);
@@ -125,7 +126,8 @@ public class DefaultTaskDivideStrategyTest {
             DataType.COMMON_MESSAGE.ordinal(),
             false,
             "",
-            ""
+            "",
+            "TagA||TagB"
         );
         List<KeyValue> taskConfigs = config.getTaskDivideStrategy().divide(topicRouteMap, tdc, 4);
         assertThat(taskConfigs.size()).isEqualTo(4);
@@ -183,6 +185,7 @@ public class DefaultTaskDivideStrategyTest {
             "",
             DataType.COMMON_MESSAGE.ordinal(),
             false,
+            "",
             "",
             ""
         );


### PR DESCRIPTION
## What is the purpose of the change

#132

Utilize RocketMQ's Tag filtering mechanism，before message synchronization, define filtering rules and synchronize only the messages that meet the filtering rules.

When sending an http request to start the rocketmq-replicator, add the filter-rule parameter to the parameter list
![image](https://user-images.githubusercontent.com/18254437/167972938-c3648474-af79-4922-a058-1c2465315134.png)



