### PR TITLE
Clean up duplicate methods

### DIFF
--- a/rocketmq-connect-runtime/src/main/java/org/apache/rocketmq/connect/runtime/connectorwrapper/WorkerDirectTask.java
+++ b/rocketmq-connect-runtime/src/main/java/org/apache/rocketmq/connect/runtime/connectorwrapper/WorkerDirectTask.java
@@ -179,10 +179,6 @@ public class WorkerDirectTask implements WorkerTask {
                 return taskConfig;
             }
 
-            @Override public KeyValue configs() {
-                return taskConfig;
-            }
-
             @Override
             public void resetOffset(RecordPartition recordPartition, RecordOffset recordOffset) {
 
@@ -230,9 +226,6 @@ public class WorkerDirectTask implements WorkerTask {
                 return taskConfig.getString(RuntimeConfigDefine.TASK_ID);
             }
 
-            @Override public KeyValue configs() {
-                return taskConfig;
-            }
             /**
              * Get the configurations of current task.
              *


### PR DESCRIPTION
## What is the purpose of the change

Clean up some duplicate methods in org.apache.rocketmq.connect.runtime.connectorwrapper

## Brief changelog

both in the `startSourceTask()` and `starkSinkTask()`,  `public KeyValue configs()` is redundant.