### PR TITLE
Fix: compare Enum with String is Never equal

### DIFF
--- a/rocketmq-connect-runtime/src/main/java/org/apache/rocketmq/connect/runtime/rest/ConnectorPluginsResource.java
+++ b/rocketmq-connect-runtime/src/main/java/org/apache/rocketmq/connect/runtime/rest/ConnectorPluginsResource.java
@@ -100,7 +100,7 @@ public class ConnectorPluginsResource {
     public void listConnectorPlugins(Context context) {
         synchronized (this) {
             List<PluginInfo> pluginInfos = Collections.unmodifiableList(connectorPlugins.stream()
-                    .filter(p -> PluginType.SINK.toString().equals(p.getType()) || PluginType.SOURCE.toString().equals(p.getType()))
+                    .filter(p -> PluginType.SINK.equals(p.getType()) || PluginType.SOURCE.equals(p.getType()))
                     .collect(Collectors.toList()));
             context.json(new HttpResponse<>(context.status(), pluginInfos));
         }


### PR DESCRIPTION
## plugin/list/connectors 

plugin/list/connectors response body is always : { "status":200,"body":[]}