### PR TITLE
support vscode ide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ devenv
 .idea/
 *.versionsBackup
 .DS_Store
+.vscode

--- a/rocketmq-connect-runtime/src/test/java/org/apache/rocketmq/connect/runtime/controller/isolation/TestFileSystem.java
+++ b/rocketmq-connect-runtime/src/test/java/org/apache/rocketmq/connect/runtime/controller/isolation/TestFileSystem.java
@@ -17,8 +17,6 @@
 
 package org.apache.rocketmq.connect.runtime.controller.isolation;
 
-import org.jetbrains.annotations.NotNull;
-import com.sun.nio.zipfs.JarFileSystemProvider;
 import java.io.IOException;
 import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
@@ -28,6 +26,8 @@ import java.nio.file.WatchService;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.Set;
+
+import org.jetbrains.annotations.NotNull;
 
 public class TestFileSystem extends FileSystem {
     @Override


### PR DESCRIPTION
## What is the purpose of the change

support vscode ide


## Brief changelog

git ignore vscode project fille.
remove unused "jdk internal api" for "eclipse jdt" build error.